### PR TITLE
Set the main font to Comic Sans MS

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -5,6 +5,7 @@ date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
 output: bookdown::gitbook
 documentclass: book
+mainfont: Comic Sans MS
 bibliography: [book.bib, packages.bib]
 biblio-style: apalike
 link-citations: yes
@@ -16,8 +17,6 @@ options(bookdown.post.latex =function(x) {
  gsub('(?<=\\\\includegraphics\\[)', 'fbox,', x, perl = TRUE)
 })
 ```
-
-\setmainfont{Comic Sans MS}
 
 \includepdf[scale=1]{pdf page to insert.pdf}
 


### PR DESCRIPTION
It is too late to `\setmainfont{Comic Sans MS}` in the body of the document. It should be done in the preamble so that the font is applied to the full document, including the title page and TOC, etc.